### PR TITLE
Develop

### DIFF
--- a/Modbus485Master/README.md
+++ b/Modbus485Master/README.md
@@ -2,15 +2,14 @@
 
 This library allows an imp to communicate with other devices via the Modbus-RS485 protocol.
 
-**To use this library, add the following statements**
+**To use this library, add the following statements to the top of your device code:**
 
-```#require "CRC16.class.nut:1.0.0"
+```
+#require "CRC16.class.nut:1.0.0"
 #require "ModbusRTU.class.nut:1.0.0"
 #require "ModbusMaster.class.nut:1.0.0"
 #require "Modbus485Master.class.nut:1.0.0"
 ```
-
-**to the top of your device code.**
 
 ## Hardware Setup
 
@@ -209,7 +208,7 @@ modbus.diagnostics(0x01, MODBUSRTU_SUB_FUNCTION_CODE.RESTART_COMMUNICATION_OPTIO
 
 Function Code : 17
 
-This method reads the description of the type, the current status and other information specific to a remote device whose address is specified in the method’s first parameter. The second, optional parameter is a function that will be fired when a response regarding this request is received. It takes two parameters, *error* and *result*.  
+This method reads the description of the type, the current status and other information specific to a remote device whose address is specified in the method’s first parameter. The second, optional parameter is a function that will be fired when a response regarding this request is received. It takes two parameters, *error* and *result*.
 
 #### Example
 
@@ -220,7 +219,7 @@ modbus.reportSlaveID(0x01, function(error, result) {
     } else {
         server.log("Run indicator : " + result.runIndicator);
         server.log(result.slaveId);
-    }        
+    }
 }.bindenv(this));
 ```
 
@@ -232,7 +231,7 @@ This method modifies the contents of a specified holding register using a combin
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
-| *deviceAddress* | Integer | Yes | N/A | The unique address that identifies a device |   
+| *deviceAddress* | Integer | Yes | N/A | The unique address that identifies a device |
 | *referenceAddress* | Integer | Yes | N/A | The address of the holding register the value is written into |
 | *AND_mask* | Integer | Yes | N/A | The AND mask |
 | *OR_mask* | Integer | Yes | N/A | The OR mask |
@@ -246,7 +245,7 @@ modbus.maskWriteRegister(0x01, 0x10, 0xFFFF, 0x0000, function(error, result) {
         server.error(error);
     } else {
         server.log(result);
-    }        
+    }
 }.bindenv(this));
 ```
 
@@ -274,7 +273,7 @@ modbus.readWriteMultipleRegisters(0x01, 0x10, 0xFFFF, 0x0000, function(error, re
         server.error(error);
     } else {
         server.log(result);
-    }        
+    }
 }.bindenv(this));
 ```
 

--- a/Modbus485Master/README.md
+++ b/Modbus485Master/README.md
@@ -48,7 +48,7 @@ modbus <- Modbus485Master(hardware.uart2, hardware.pinL);
 
 ## Modbus485Master Class Methods
 
-### read(*deviceAddress, targetType, startingAddress, quantity, values[, callback]*)
+### read(*deviceAddress, targetType, startingAddress, quantity[, callback]*)
 
 Function Code : 01, 02, 03, 04
 

--- a/Modbus485Master/README.md
+++ b/Modbus485Master/README.md
@@ -27,7 +27,7 @@ The following instructions are applicable to Electric Imp’s [impAccelerator&tr
 
 This is the main library class. It implements most of the functions listed in the [Modbus specification](http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf).
 
-### Constructor: Modbus485Master(*uart, rts, params*)
+### Constructor: Modbus485Master(*uart, rts[, params]*)
 
 Instantiate a new Modbus485Master object and set the configuration of the UART bus over which it operates. The parameters *uart* and *rts* are, respectively, the imp UART in use and an imp GPIO pin which will be used to control flow. The *params* parameter is optional and takes a table containing the following keys:
 
@@ -268,13 +268,6 @@ This method performs a combination of one read operation and one write operation
 #### Example
 
 ```squirrel
-modbus.readWriteMultipleRegisters(0x01, 0x10, 0xFFFF, 0x0000, function(error, result) {
-    if (error) {
-        server.error(error);
-    } else {
-        server.log(result);
-    }
-}.bindenv(this));
 ```
 
 ### readDeviceIdentification(*deviceAddress, readDeviceIdCode, objectId[, callback]*)

--- a/Modbus485Master/example/example.device.nut
+++ b/Modbus485Master/example/example.device.nut
@@ -1,5 +1,6 @@
 #require "CRC16.class.nut:1.0.0"
 #require "ModbusRTU.class.nut:1.0.0"
+#require "ModbusMaster.class.nut:1.0.0"
 #require "Modbus485Master.class.nut:1.0.0"
 
 // this example demonstrates how to write and read values into/from holding registers

--- a/Modbus485Slave/README.md
+++ b/Modbus485Slave/README.md
@@ -2,15 +2,13 @@
 
 This library empowers an imp to communicate with the Modbus Master via the RS485 protocol.
 
-**To use this library, add**
+**To use this library, add the following statements to the top of your device code:**
 
 ```squirrel
 #require "CRC16.class.nut:1.0.0"
 #require "ModbusSlave.class.nut:1.0.0"
 #require "Modbus485Slave.class.nut:1.0.0"
 ```
-
-**to the top of your device code.**
 
 ## Hardware Setup
 

--- a/ModbusRTU/README.md
+++ b/ModbusRTU/README.md
@@ -1,15 +1,13 @@
 # ModbusRTU
 
-This library creates and parses Modbus Protocol Data Units (PDU).
+This library creates and parses Modbus Protocol Data Units (PDU). It depends on Electric Imp's [CRC16 library](https://github.com/electricimp/CRC16) to calculate the [CRC-16](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) value of a string or blob.
 
-**To use this library, add**
+**To use this library, add the following statements to the top of your device code:**
 
 ```
 #require "CRC16.class.nut:1.0.0"
 #require "ModbusRTU.class.nut:1.0.0"
 ```
-
-**to the top of your device code.**
 
 ## ModbusRTU Class Usage
 

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -51,7 +51,7 @@ This method configures the network and opens a TCP connection with the device. I
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
-| *connectionSettings* | Table | Yes | N/A | The connection settings. It entails the device IP and port.<br/>Device IP can either be string or array of four bytes, for example: `[192, 168, 1, 37]` or `"192.168.1.37"`.<br/>Port can either be an integer or array of two bytes (high and low bytes of unsigned two-byte integer value), for example: `[0x10, 0x92]` or `4242` |
+| *connectionSettings* | Table | Yes | N/A | The device IP address and port. The device IP address can either be a string or an array of four bytes, for example: `[192, 168, 1, 37]` or `"192.168.1.37"`. The port can either be an integer or array of two bytes (the high and low bytes of an unsigned two-byte integer value), for example: `[0x10, 0x92]` or `4242` |
 | *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established |
 | *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established |
 

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -8,7 +8,7 @@ This library allows an imp to communicate with other devices via TCP/IP. It requ
 #require "ModbusRTU.class.nut:1.0.0"
 #require "ModbusMaster.class.nut:1.0.0"
 #require "ModbusTCPMaster.class.nut:1.0.0"
-#require "W5500.class.nut"
+#require "W5500.device.nut:1.0.0"
 ```
 
 **to the top of your device code.**

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -51,7 +51,7 @@ This method configures the network and opens a TCP connection with the device. I
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
-| *connectionSettings* | Table | Yes | N/A | The connection settings. It entails the device IP and port |
+| *connectionSettings* | Table | Yes | N/A | The connection settings. It entails the device IP and port.<br/>Device IP can either be string or array of four bytes, for example: `[192, 168, 1, 37]` or `"192.168.1.37"`.<br/>Port can either be an integer or array of two bytes (high and low bytes of unsigned two-byte integer value), for example: `[0x10, 0x92]` or `4242` |
 | *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established |
 | *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established |
 
@@ -62,8 +62,8 @@ This method configures the network and opens a TCP connection with the device. I
 ```squirrel
 // The device address and port
 local connectionSettings = {
-    "destIP"     : [192, 168, 1, 90],
-    "destPort"   : [0x01, 0xF6]
+    "destIP"     : "192.168.1.90",
+    "destPort"   : 502
 };
 
 // Open the connection

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -25,9 +25,9 @@ The following instructions are applicable to Electric Imp’s [impAccelerator&tr
 
 This is the main library class. It implements most of the functions listed in the [Modbus specification](http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf).
 
-### Constructor: ModbusTCPMaster(*wiz, debug*)
+### Constructor: ModbusTCPMaster(*wiz[, debug]*)
 
-Instantiate a new ModbusTCPMaster object. It takes two parameters: *wiz*, the Wiznet W5500 object that is driving the Ethernet link, and *debug* which, if enabled, prints the outgoing and incoming ADU for debugging purposes.
+Instantiate a new ModbusTCPMaster object. It takes one required parameter: *wiz*, the [Wiznet W5500](https://github.com/electricimp/Wiznet_5500) object that is driving the Ethernet link, and one optional boolean parameter: *debug* which, if enabled, prints the outgoing and incoming ADU for debugging purposes. The defualt value of *debug* is `false`.
 
 #### Example
 
@@ -55,7 +55,7 @@ This method configures the network and opens a TCP connection with the device. I
 | *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established |
 | *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established |
 
-**Note** If an *onReconnectCallback* is not supplied, when the connection is re-established, the *onConnectCallback* will be fired.
+**Note:** If an *onReconnectCallback* is not supplied, when the connection is re-established, the *onConnectCallback* will be fired.
 
 #### Example
 
@@ -76,9 +76,9 @@ modbus.connect(connectionSettings, function(error, conn){
 });
 ```
 
-### disconnect(*callback*)
+### disconnect(*[callback]*)
 
-This method closes the existing TCP connection.
+This method closes the existing TCP connection. It takes one optional parameter: *callback*, a function that will be executed when the connection has been closed.
 
 #### Example
 
@@ -86,7 +86,7 @@ This method closes the existing TCP connection.
 modbus.disconnect();
 ```
 
-### read(*targetType, startingAddress, quantity, values[, callback]*)
+### read(*targetType, startingAddress, quantity[, callback]*)
 
 Function Code : 01, 02, 03, 04
 
@@ -144,7 +144,7 @@ This is a generic method used to write values into coils or registers. It has th
 | *values* | Integer, array, bool, blob | Yes | N/A | The values written into Coils or Registers. Please view ‘Notes’, below |
 | *callback* | Function | No | Null | The function to be fired when it receives response regarding this request. It takes two parameters, *error* and *result* |
 
-#### Notes
+#### Notes:
 
 1. Integer, blob and array[integer] are applicable to *MODBUSRTU_TARGET_TYPE.HOLDING_REGISTER*. Use array[integer] only when *quantity* is greater than one.
 
@@ -300,13 +300,6 @@ This method performs a combination of one read operation and one write operation
 #### Example
 
 ```squirrel
-modbus.readWriteMultipleRegisters(0x10, 0xFFFF, 0x0000, function(error, result) {
-    if (error) {
-        server.error(error);
-    } else {
-        server.log(result);
-    }
-}.bindenv(this));
 ```
 
 ### readDeviceIdentification(*readDeviceIdCode, objectId, [callback]*)

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -2,7 +2,7 @@
 
 This library allows an imp to communicate with other devices via TCP/IP. It requires the use of [Wiznet](https://github.com/electricimp/Wiznet_5500) to transmit the packets between devices via Ethernet.
 
-**To use this library, add**
+**To use this library, add the following statements to the top of your device code:**
 
 ```
 #require "ModbusRTU.class.nut:1.0.0"
@@ -10,8 +10,6 @@ This library allows an imp to communicate with other devices via TCP/IP. It requ
 #require "ModbusTCPMaster.class.nut:1.0.0"
 #require "W5500.device.nut:1.0.0"
 ```
-
-**to the top of your device code.**
 
 The following instructions are applicable to Electric Imp’s [impAccelerator&trade; Fieldbus Gateway](https://electricimp.com/docs/hardware/resources/reference-designs/fieldbusgateway/).
 
@@ -255,7 +253,7 @@ modbus.reportSlaveID(function(error, result) {
     } else {
         server.log("Run indicator : " + result.runIndicator);
         server.log(result.slaveId);
-    }        
+    }
 }.bindenv(this));
 ```
 
@@ -280,7 +278,7 @@ modbus.maskWriteRegister(0x10, 0xFFFF, 0x0000, function(error, result) {
         server.error(error);
     } else {
         server.log(result);
-    }        
+    }
 }.bindenv(this));
 ```
 
@@ -307,7 +305,7 @@ modbus.readWriteMultipleRegisters(0x10, 0xFFFF, 0x0000, function(error, result) 
         server.error(error);
     } else {
         server.log(result);
-    }        
+    }
 }.bindenv(this));
 ```
 

--- a/ModbusTCPMaster/example/device.example.nut
+++ b/ModbusTCPMaster/example/device.example.nut
@@ -1,4 +1,4 @@
-#require "W5500.class.nut:1.0.0"
+#require "W5500.device.nut:1.0.0"
 #require "ModbusRTU.class.nut:1.0.0"
 #require "ModbusMaster.class.nut:1.0.0"
 #require "ModbusTCPMaster.class.nut:1.0.0"


### PR DESCRIPTION
I have started to update the doc's on this library, but more needs to be done. 

Pull request includes the following changes -
Modbus485Master readme:
- Added missing require statement
- Clarified constructor optional parameters 
- Deleted extra parameter in read()
- Deleted example from readWriteMultipleRegisters, since it did not have the correct parameters and thus would not compile
Modbus485 example:
- Added missing require statements
ModbusRTU:
- Added language and link to CRC16 library so dependency is better understood
ModbusTCPMaster:
- Fixed incorrect W5500 require statement
- Clarified constructor optional parameters 
- Updated connect() `connectionSettings` parameter description
- Updated connect() example code to use no array parameters
- Clarified disconnect() optional parameters 
- Deleted extra parameter in read()
- Deleted example from readWriteMultipleRegisters, since it did not have the correct parameters and thus would not compile
ModbusTCPMaster example:
- Fixed incorrect W5500 require statement

More errors that I have not addressed yet:
- Please replace the readWriteMultipleRegisters examples I have deleted 
ModbusTCPMaster: 
- connect callbacks take parameters - please document what they are
- if disconnect callback takes any parameters please document what they are
ModbusTCPMaster example:
- line 26 modbus.connect doesn't have the correct parameters, and so the code doesn't compile

I have not looked at or used the slave files, so please review those.  