### PR TITLE
1. fixed the parsing error when requests are made in quick succession .

### DIFF
--- a/Modbus485Master/README.md
+++ b/Modbus485Master/README.md
@@ -254,7 +254,7 @@ modbus.maskWriteRegister(0x01, 0x10, 0xFFFF, 0x0000, function(error, result) {
 
 Function Code : 23
 
-This method performs a combination of one read operation and one write operation in a single Modbus transaction. The write operation is performed before the read. It takes the following parameters:
+This method performs a combination of one read operation and one write operation in a single Modbus transaction. The write operation is performed before the read ^. It takes the following parameters:
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
@@ -265,6 +265,9 @@ This method performs a combination of one read operation and one write operation
 | *writeQuantity* | Integer | Yes | N/A | The number of consecutive addresses values are written into |
 | *writeValue* | Blob | Yes | N/A | The value written into the holding register |
 | *callback* | Function | No | Null | The function to be fired when it receives response regarding this request. It takes two parameters, *error* and *result* |
+
+**Note** The actual order of operation is determined by the implementation of user's device.
+
 
 #### Example
 

--- a/ModbusTCPMaster/ModbusTCPMaster.class.nut
+++ b/ModbusTCPMaster/ModbusTCPMaster.class.nut
@@ -130,11 +130,12 @@ class ModbusTCPMaster extends ModbusMaster {
     function _send(PDU, properties) {
         _transactions[_transactionCount] <- properties;
         local ADU = _createADU(PDU);
+        // with or without success in transmission of data, the transaction count would be advanced
+        _transactionCount = (_transactionCount + 1) % MAX_TRANSACTION_COUNT;
         _connection.transmit(ADU, function(error) {
             if (error) {
                 _callbackHandler(error, null, properties.callback);
             } else {
-                _transactionCount = (_transactionCount + 1) % MAX_TRANSACTION_COUNT;
                 _log(ADU, "Outgoing ADU: ");
             }
         }.bindenv(this));

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -57,7 +57,10 @@ This method configures the network and opens a TCP connection with the device. I
 | *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established |
 | *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established |
 
-**Note** If an *onReconnectCallback* is not supplied, when the connection is re-established, the *onConnectCallback* will be fired.
+**Note**
+
+1. If an *onReconnectCallback* is not supplied, when the connection is re-established, the *onConnectCallback* will be fired.
+2. Depending on the configuration of the device, the connection will be severed after a certain amount of time and try to re-establish itself. Users of concern are advised to pass in a *onReconnectCallback* to handle this situation. Please refer to the device spec for more information on how to configure the default idle time.
 
 #### Example
 
@@ -288,7 +291,7 @@ modbus.maskWriteRegister(0x10, 0xFFFF, 0x0000, function(error, result) {
 
 Function Code : 23
 
-This method performs a combination of one read operation and one write operation in a single Modbus transaction. The write operation is performed before the read. It takes the following parameters:
+This method performs a combination of one read operation and one write operation in a single Modbus transaction. The write operation is performed before the read ^. It takes the following parameters:
 
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
@@ -298,6 +301,8 @@ This method performs a combination of one read operation and one write operation
 | *writeQuantity* | Integer | Yes | N/A | The number of consecutive addresses values are written into |
 | *writeValue* | Blob | Yes | N/A | The value written into the holding register  |
 | *callback* | Function | No | Null | The function to be fired when it receives response regarding this request. It takes two parameters, *error* and *result* |
+
+**Note** The actual order of operation is determined by the implementation of user's device.
 
 #### Example
 

--- a/ModbusTCPMaster/README.md
+++ b/ModbusTCPMaster/README.md
@@ -52,8 +52,8 @@ This method configures the network and opens a TCP connection with the device. I
 | Parameter | Data Type | Required | Default Value | Description |
 | --- | --- | --- | --- | --- |
 | *connectionSettings* | Table | Yes | N/A | The device IP address and port. The device IP address can either be a string or an array of four bytes, for example: `[192, 168, 1, 37]` or `"192.168.1.37"`. The port can either be an integer or array of two bytes (the high and low bytes of an unsigned two-byte integer value), for example: `[0x10, 0x92]` or `4242` |
-| *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established |
-| *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established |
+| *onConnectCallback* | Function | No | Null | The function to be fired when the connection is established. The callback takes `error` and `conn` as parameters |
+| *onReconnectCallback* | Function | No | Null| The function to be fired when the connection is re-established. The callback takes `error` and `conn` as parameters |
 
 **Note**
 
@@ -305,6 +305,16 @@ This method performs a combination of one read operation and one write operation
 #### Example
 
 ```squirrel
+modbus.readWriteMultipleRegisters(0x0A, 2, 0x0A, 2, [28, 88], function(error, result) {
+    if (error) {
+        server.error(error);
+    } else {
+        foreach (index, value in result) {
+            server.log(format("Index : %d, value : %d", index, value));
+        }
+    }
+});
+
 ```
 
 ### readDeviceIdentification(*readDeviceIdCode, objectId, [callback]*)

--- a/ModbusTCPMaster/example/device.example.nut
+++ b/ModbusTCPMaster/example/device.example.nut
@@ -23,7 +23,7 @@ local connectionSettings = {
 };
 
 // open the connection
-modbus.connect(networkSettings, connectionSettings, function(error, conn) {
+modbus.connect(connectionSettings, function(error, conn) {
     if (error) {
         server.log(error);
     } else {

--- a/ModbusTCPMaster/tests/device.test.nut
+++ b/ModbusTCPMaster/tests/device.test.nut
@@ -390,6 +390,30 @@ class DeviceTestCase extends ImpTestCase {
         }.bindenv(this));
     }
 
+    // this test will timeout when it fails
+    function testSendRequestsInSuccession() {
+        return Promise(function(resolve, reject) {
+            _connection.then(function(value) {
+                local address = 0x0A;
+                local value = false;
+                local quantity = 1;
+                local isSuccess = false;
+                _modbus.write(MODBUSRTU_TARGET_TYPE.COIL, address, quantity, value, function(error, result) {
+                    if (isSuccess) {
+                        resolve(PASS_MESSAGE);
+                    }
+                    isSuccess = true;
+                }.bindenv(this));
+                _modbus.write(MODBUSRTU_TARGET_TYPE.COIL, address, quantity, value, function(error, result) {
+                    if (isSuccess) {
+                        resolve(PASS_MESSAGE);
+                    }
+                    isSuccess = true;
+                }.bindenv(this));
+            }.bindenv(this));
+        }.bindenv(this));
+    }
+
     function tearDown() {
         _modbus.disconnect();
         return "Connection closed";


### PR DESCRIPTION
A new test case was written for it

2. Added notes to advise users of the TCP connection dropout after a
certain amount of idle time

3. Added notes to inform users that the order of operation in
readWriteMultipleRegisters may differ from the modus spec in reality .